### PR TITLE
exclude antonmedv/expr from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,8 @@
   ],
   "postUpdateOptions": [
     "gomodTidy"
+  ],
+  "ignoreDeps": [
+    "github.com/antonmedv/expr"
   ]
 }


### PR DESCRIPTION
`renovate` doesn't manage correctly the dependency upgrade, see https://github.com/antonmedv/expr/issues/46.