### PR TITLE
Fix configuration file loading

### DIFF
--- a/specs/configmap-kynaptik-http.yaml
+++ b/specs/configmap-kynaptik-http.yaml
@@ -4,15 +4,17 @@ metadata:
   namespace: default
   name: kynaptik-http-configmap
 data:
-  function-spec: |
+  function-spec.yml: |
     condition: |
-      foo == "test"
+      data.message != ""
 
     action:
-      uri: 'https://foo-bar'
-      method: GET
+      uri: 'https://webhook.site/{{ .data.key }}'
+      method: POST
       headers:
         Content-Type: application/json
 
       body: |
-        test
+        {
+          message: {{ .data.message }}
+        }


### PR DESCRIPTION
Fix access to `configMap`, which is provided in the following path by [Fission](https://docs.fission.io/usage/access-secret-cfgmap-in-function/):

```
/configs/<namespace>/<name>/function-spec.yaml
```

As the `<name>` is not known by the function, the current implementation walks the file system until it finds the configuration file.

To facilitate testing, the current implementation uses a FileSystem [abstraction](https://github.com/spf13/afero), with a mock (in memory) filesystem for testing.